### PR TITLE
new log writer supporting bunyan out-of-the-box

### DIFF
--- a/lib/log/writers/bunyanJson.js
+++ b/lib/log/writers/bunyanJson.js
@@ -1,0 +1,21 @@
+var bunyan = require('bunyan');
+module.exports = function () {
+  var pub = {};
+  var levels = [
+    'fatal',
+    'error',
+    'warn',
+    'info',
+    'debug',
+    'trace'
+  ];
+  var logger;
+  pub.output = function ( logObject ) {
+    logger = logger || bunyan.createLogger( { name: logObject.application } );
+    logObject.level = levels[ logObject.level ];
+    logger[ logObject.level ]( logObject.message );
+  };
+  pub.getEntries = function() {};
+  pub.reset = function() {};
+  return pub;
+};


### PR DESCRIPTION
very simple [bunyan](https://github.com/trentm/node-bunyan) support

To use it just use:
```
var ioc = require('simple-ioc').setSettings({ log: { output: 'bunyanJson' } });
var container = ioc.getContainer();
```