### PR TITLE
autoRegisterPath converts hyphenated to camelCase.

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,6 +654,7 @@ Files that contains the followin comments will be handeled different by autoRegi
 If omitFileLengthLogging is not set, the ioc will info log if files exceed 100 lines and warning log if files exceed 200 lines.
 
 Normally the ioc uses the name of the file as name of the component, but if the function is not anonymous, the name of the function is used.
+In case the name of the component is hyphenated (`some-component.js`), it will be camelCased when injected (`someComponent`).
 
 #### Example
 ```javascript

--- a/lib/container.js
+++ b/lib/container.js
@@ -105,7 +105,8 @@ module.exports = function( ioc, trueCallback ) {
 		log.trace( 'autoRegisterPath', relativePath );
 		var modulesInPath = files.getModulesInPath( relativePath, omitFileIocComments, omitFileLengthLogging, 2 );
 		Object.keys( modulesInPath.injectables ).forEach( function( name ) {
-			pub.registerInjectable( name, modulesInPath.injectables[ name ] );
+			var exposedName = name.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase(); });
+			pub.registerInjectable( exposedName, modulesInPath.injectables[ name ] );
 		} );
 		Object.keys( modulesInPath.resolved ).forEach( function( name ) {
 			pub.registerResolved( name, modulesInPath.resolved[ name ] );

--- a/tests/function/containerFunctionTests.js
+++ b/tests/function/containerFunctionTests.js
@@ -65,6 +65,14 @@ describe( 'lib/container', function() {
 					callback();
 				} );
 		} );
+		it( 'Should convert hyphenated modules to camelCased when using autoRegisterPath', function( callback ) {
+			container.autoRegisterPath( './containerTestData/test3', true )
+				.resolve( 'hyphenatedModule', function( err, instance ) {
+					assert.equal( err, undefined );
+					assert.equal( 'hyphenated!', instance.value );
+					callback();
+				} );
+		} );
 		it( 'Should throw error if components are registered more than once', function() {
 			try {
 				container.autoRegisterPath( './containerTestData/test2' );

--- a/tests/function/containerTestData/test3/hyphenated-module.js
+++ b/tests/function/containerTestData/test3/hyphenated-module.js
@@ -1,0 +1,3 @@
+module.exports = function( pub ) {
+  pub.value = 'hyphenated!';
+};


### PR DESCRIPTION
There are few edge-cases I am not handling, if users find themselves in those cases, they can open an Issue I suppose.

There are also a test and minimal documentation to this change.