### PR TITLE
Fix for node 8.x

### DIFF
--- a/lib/genericHelpers/anonymousParentResolver.js
+++ b/lib/genericHelpers/anonymousParentResolver.js
@@ -10,11 +10,22 @@ module.exports = function( parentModule ) {
 		} ); };
 		var stack = err.stack;
 		Error.prepareStackTrace = prepareStackTraceBackup;
+		
+		//fix for node v8
+		stack = stack.reduce(function(sum, a) {
+			if (a !== null && typeof(a) !== 'undefined') {
+				sum.push(a);
+			}
+			return sum;
+		}, []);
+
 		while( stack.length ) {
-			if( !stepsBack )
+			if (!stepsBack) {
 				return filename;
+			}
+
 			var top = stack.shift();
-			if( top !== filename ) {
+			if(top !== filename) {
 				stepsBack--;
 				filename = top;
 			}

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "npm -s run test-unit && npm -s run test-function",
-    "test-unit": "echo ' --- Unit tests --- ' && node_modules/.bin/_mocha --reporter spec --colors --recursive tests/unit",
-    "test-function": "echo ' --- Function tests --- ' && node_modules/.bin/_mocha --reporter spec --colors --recursive tests/function",
-    "test-file": "node_modules/.bin/_mocha --reporter spec --colors --recursive $1"
+    "test-unit": "echo ' --- Unit tests --- ' && node ./node_modules/mocha/bin/mocha --reporter spec --colors --recursive tests/unit",
+    "test-function": "echo ' --- Function tests --- ' && node ./node_modules/mocha/bin/mocha --reporter spec --colors --recursive tests/function",
+    "test-file": "node ./node_modules/mocha/bin/mocha --reporter spec --colors --recursive $1"
   },
   "keywords": [
     "ioc",


### PR DESCRIPTION
Found an issue where the stack traces in node version 8 can include null values, which can cause the getParentFilename method to fail.

Modified this so it copes with null values in the stack.

Also corrected the scripts for running the tests as they didn't work out of the box for me.