### PR TITLE
fix: handle function toString node10 change

### DIFF
--- a/lib/containerHelpers/dependencyParser.js
+++ b/lib/containerHelpers/dependencyParser.js
@@ -48,7 +48,7 @@ module.exports = function() {
 		var fnString = fn.toString();
 		var parameters = fnString
 			.replace( /\n/g, ' ' )
-			.match( /function\s+\w*\s*\((.*?)\)/ )[ 1 ].split( /\s*,\s*/ )
+			.match( /function\s?\w*\s*\((.*?)\)/ )[ 1 ].split( /\s*,\s*/ )
 			.map( function( parameterName ) { return parameterName.trim(); } )
 			.filter( function( parameterName ) { return parameterName.length > 0; } )
 			.map( function( parameterName ) {

--- a/tests/unit/lib/containerHelpers/dependencyParserUnitTests.js
+++ b/tests/unit/lib/containerHelpers/dependencyParserUnitTests.js
@@ -23,6 +23,18 @@ describe( 'lib/dependencyParser', function() {
 		} );
 	} );
 	describe( 'getDependencies', function() {
+		describe( 'old node compatibility', function() {
+			it( 'function.toString() is different in node 10', function() {
+				// https://github.com/nodejs/node/issues/20355
+				var node9andBelowfunc = function () {};
+				node9andBelowfunc.toString = function() { return "function () {}"};
+				dependencyParser.getDependencies(node9andBelowfunc);
+
+				var node10andAbovefunc = function (){};
+				node10andAbovefunc.toString = function() { return "function() {}"};
+				dependencyParser.getDependencies(node10andAbovefunc);
+			} );
+		} );
 		describe( 'parameters', function() {
 			it( 'Should have the correct parameters', function() {
 				var dependencies = dependencyParser.getDependencies( function( callback, parentName, pub, setup, p1, p2 ) {

--- a/tests/unit/lib/containerHelpers/storeUnitTests.js
+++ b/tests/unit/lib/containerHelpers/storeUnitTests.js
@@ -118,7 +118,7 @@ describe( 'lib/containerHelpers/store', function() {
 	describe( 'getAllResolvingProblems()', function() {
 		it( 'Should return all resolving problems', function() {
 			var problems = store.getAllResolvingProblems().sort( function( problem1, problem2 ) {
-				return problem1 < problem2 ? 1 : -1;
+				return problem1 < problem2 ? -1 : 1;
 			} );
 			assert.deepEqual( problems, [
 				{ name: 'injectable1', errors: [


### PR DESCRIPTION
In node 10 the space preceding with () is removed.

This causes the error:

      TypeError: Cannot read properties of null (reading '1')